### PR TITLE
dvc-objects: drop python 3.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: '3.7'
+        python-version: '3.8'
 
     - name: Upgrade pip and nox
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        pyv: ['3.7', '3.8', '3.9', '3.10']
+        pyv: ['3.8', '3.9', '3.10']
 
     steps:
     - name: Check out the repository

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -43,7 +43,7 @@ Request features on the `Issue Tracker`_.
 How to set up your development environment
 ------------------------------------------
 
-You need Python 3.7+ and the following tools:
+You need Python 3.8+ and the following tools:
 
 - Nox_
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ nox.options.sessions = "lint", "tests"
 locations = "src", "tests"
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.8", "3.9", "3.10"])
 def tests(session: nox.Session) -> None:
     session.install(".[tests]")
     session.run(

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,14 +11,13 @@ authors = Iterative
 maintainer_email = support@dvc.org
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Development Status :: 4 - Beta
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = False
 package_dir=
     =src
@@ -32,7 +31,6 @@ install_requires=
     fsspec>=2021.10.1
     nanotime>=0.5.2
     typing-extensions>=3.7.4
-    jaraco.windows>=5.7.0; python_version < '3.8' and sys_platform == 'win32'
 
 [options.extras_require]
 tests =

--- a/src/dvc_objects/fs/system.py
+++ b/src/dvc_objects/fs/system.py
@@ -12,19 +12,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-if os.name == "nt" and sys.version_info < (3, 8):
-    # NOTE: using backports for `os.path.realpath`
-    # See https://bugs.python.org/issue9949 for more info.
-    # pylint: disable=import-error, no-name-in-module
-    from jaraco.windows.filesystem.backports import realpath as _realpath
-
-    def realpath(path):
-        return _realpath(os.fspath(path))
-
-else:
-    realpath = os.path.realpath
-
-
 umask = os.umask(0)
 os.umask(umask)
 
@@ -38,7 +25,7 @@ def hardlink(source: "AnyFSPath", link_name: "AnyFSPath") -> None:
     # See https://bugs.python.org/issue41355 for more info.
     st = os.lstat(source)
     if stat.S_ISLNK(st.st_mode):
-        src = realpath(source)
+        src = os.path.realpath(source)
     else:
         src = source
 


### PR DESCRIPTION
Part of https://github.com/iterative/dvc/issues/7708

Otherwise we are forced to create a conda package for `jaraco.windows`, which
is not a big deal, but since we are about to drop 3.7, might as well just do
that.