### PR TITLE
gs: Allow reading proxy config from env.

### DIFF
--- a/src/dvc_objects/fs/implementations/gs.py
+++ b/src/dvc_objects/fs/implementations/gs.py
@@ -15,6 +15,7 @@ class GSFileSystem(ObjectFileSystem):
         login_info = {"consistency": None}
         login_info["project"] = config.get("projectname")
         login_info["token"] = config.get("credentialpath")
+        login_info["session_kwargs"] = {"trust_env": True}
         return login_info
 
     @wrap_prop(threading.Lock())


### PR DESCRIPTION
We were not passing `trust_env` to aiohttp:

https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support

Discord context: https://discord.com/channels/485586884165107732/968618527990906900