### PR TITLE
hashfile: remove redundant splits

### DIFF
--- a/src/dvc_objects/hashfile/db.py
+++ b/src/dvc_objects/hashfile/db.py
@@ -87,28 +87,6 @@ class ObjectDB:
             hash_info,
         )
 
-    def _add_file(
-        self,
-        from_fs: "FileSystem",
-        from_info: "AnyFSPath",
-        to_info: "AnyFSPath",
-        _hash_info: "HashInfo",
-        hardlink: bool = False,
-        callback: "Callback" = None,
-    ):
-        from dvc_objects.fs import generic
-        from dvc_objects.fs.callbacks import Callback
-
-        self.makedirs(self.fs.path.parent(to_info))
-        return generic.transfer(
-            from_fs,
-            from_info,
-            self.fs,
-            to_info,
-            hardlink=hardlink,
-            callback=Callback.as_callback(callback),
-        )
-
     def add(
         self,
         fs_path: "AnyFSPath",
@@ -137,13 +115,17 @@ class ObjectDB:
             desc=fs.path.name(fs_path),
             bytes=True,
         ) as cb:
-            self._add_file(
+            from dvc_objects.fs import generic
+            from dvc_objects.fs.callbacks import Callback
+
+            self.makedirs(self.fs.path.parent(cache_fs_path))
+            generic.transfer(
                 fs,
                 fs_path,
+                self.fs,
                 cache_fs_path,
-                hash_info,
                 hardlink=hardlink,
-                callback=cb,
+                callback=Callback.as_callback(cb),
             )
 
         try:

--- a/src/dvc_objects/hashfile/obj.py
+++ b/src/dvc_objects/hashfile/obj.py
@@ -52,6 +52,10 @@ class HashFile:
         )
 
     def check(self, odb: "ObjectDB", check_hash: bool = True):
+        from dvc_objects.errors import ObjectFormatError
+
+        from .hash import hash_file
+
         if not check_hash:
             assert self.fs
             if not self.fs.exists(self.fs_path):
@@ -60,13 +64,6 @@ class HashFile:
                 )
             else:
                 return None
-
-        self._check_hash(odb)
-
-    def _check_hash(self, odb):
-        from dvc_objects.errors import ObjectFormatError
-
-        from .hash import hash_file
 
         _, actual = hash_file(
             self.fs_path, self.fs, self.hash_info.name, odb.state


### PR DESCRIPTION
We used to use it in old refodb, but we don't anymore.