### PR TITLE
oss: add _strip_protocol/unstrip_protocol; add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,14 +67,13 @@ files = ["src", "tests"]
 [tool.pylint.message_control]
 enable = ["c-extension-no-member", "no-else-return"]
 disable = [
-    "format", "refactoring", "spelling", "design", "no-self-use",
-    "invalid-name", "misplaced-comparison-constant", "duplicate-code", "fixme",
+    "format", "refactoring", "spelling", "design",
+    "invalid-name", "duplicate-code", "fixme",
     "unused-wildcard-import", "cyclic-import", "wrong-import-order",
     "wrong-import-position", "ungrouped-imports", "multiple-imports",
     "logging-format-interpolation", "logging-fstring-interpolation",
     "missing-function-docstring", "missing-module-docstring",
     "missing-class-docstring", "raise-missing-from", "import-outside-toplevel",
-    "cannot-enumerate-pytest-fixtures",
 ]
 
 [tool.pylint.typecheck]

--- a/src/dvc_objects/fs/implementations/oss.py
+++ b/src/dvc_objects/fs/implementations/oss.py
@@ -33,3 +33,13 @@ class OSSFileSystem(ObjectFileSystem):
         from ossfs import OSSFileSystem as _OSSFileSystem
 
         return _OSSFileSystem(**self.fs_args)
+
+    @classmethod
+    def _strip_protocol(cls, path: str) -> str:
+        from fsspec.utils import infer_storage_options
+
+        options = infer_storage_options(path)
+        return options["host"] + options["path"]
+
+    def unstrip_protocol(self, path):
+        return "oss://" + path.lstrip("/")

--- a/tests/fs/test_strip_unstrip.py
+++ b/tests/fs/test_strip_unstrip.py
@@ -1,0 +1,78 @@
+import pytest
+
+from dvc_objects.fs.base import FileSystem
+from dvc_objects.fs.implementations import (
+    azure,
+    gs,
+    hdfs,
+    http,
+    https,
+    oss,
+    s3,
+    ssh,
+    webhdfs,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_check_requires(mocker):
+    yield mocker.patch.object(FileSystem, "_check_requires")
+
+
+@pytest.mark.parametrize(
+    "fs_cls, urlpath, stripped",
+    [
+        (azure.AzureFileSystem, "azure://container", "container"),
+        (gs.GSFileSystem, "gs://container", "container"),
+        (s3.S3FileSystem, "s3://container", "container"),
+        (oss.OSSFileSystem, "oss://container", "container"),
+        (hdfs.HDFSFileSystem, "hdfs://example.com", ""),
+        (hdfs.HDFSFileSystem, "hdfs://example.com:8020", ""),
+        (
+            http.HTTPFileSystem,
+            "http://example.com/path/to/file",
+            "http://example.com/path/to/file",
+        ),
+        (
+            https.HTTPSFileSystem,
+            "https://example.com/path/to/file",
+            "https://example.com/path/to/file",
+        ),
+        (ssh.SSHFileSystem, "ssh://example.com:/dir/path", "/dir/path"),
+        (webhdfs.WebHDFSFileSystem, "webhdfs://example.com", ""),
+        (webhdfs.WebHDFSFileSystem, "webhdfs://example.com:8020", ""),
+    ],
+)
+@pytest.mark.parametrize("path", ["", "/path"])
+def test_strip_prptocol(fs_cls, urlpath, stripped, path):
+    assert fs_cls._strip_protocol(urlpath + path) == stripped + path
+
+
+@pytest.mark.parametrize(
+    "fs_args, expected_url",
+    [
+        ({"host": "example.com"}, "hdfs://example.com"),
+        ({"host": "example.com", "port": None}, "hdfs://example.com"),
+        ({"host": "example.com", "port": 8020}, "hdfs://example.com:8020"),
+    ],
+)
+def test_hdfs_unstrip_protocol(fs_args, expected_url):
+    fs = hdfs.HDFSFileSystem(**fs_args)
+    assert fs.unstrip_protocol("/path") == expected_url + "/path"
+
+
+@pytest.mark.parametrize(
+    "fs_cls, path, expected_url",
+    [
+        (azure.AzureFileSystem, "container", "azure://container"),
+        (azure.AzureFileSystem, "container/path", "azure://container/path"),
+        (gs.GSFileSystem, "container", "gs://container"),
+        (gs.GSFileSystem, "container/path", "gs://container/path"),
+        (s3.S3FileSystem, "container", "s3://container"),
+        (s3.S3FileSystem, "container/path", "s3://container/path"),
+        (oss.OSSFileSystem, "container", "oss://container"),
+        (oss.OSSFileSystem, "container/path", "oss://container/path"),
+    ],
+)
+def test_unstrip_protocol(mocker, fs_cls, path, expected_url):
+    assert fs_cls.unstrip_protocol(mocker.MagicMock(), path) == expected_url


### PR DESCRIPTION
Runcache tests were failing due to a lack of proper `_strip_protcol`/`unstrip_protcol` in OSS. Please check other inlined comments.