### PR TITLE
gdrive: use LocalWebserverAuth instead of CommandLineAuth

### DIFF
--- a/src/dvc_objects/fs/implementations/gdrive.py
+++ b/src/dvc_objects/fs/implementations/gdrive.py
@@ -219,7 +219,7 @@ class GDriveFileSystem(FileSystem):  # pylint:disable=abstract-method
             if self._use_service_account:
                 gauth.ServiceAuth()
             else:
-                gauth.CommandLineAuth()
+                gauth.LocalWebserverAuth()
                 GDriveFileSystem._validate_credentials(gauth, auth_settings)
 
         # Handle AuthenticationError, RefreshError and other auth failures


### PR DESCRIPTION
`pydrive2.auth.CommandLineAuth` uses out of band authentication (`urn:ietf:wg:oauth:2.0:oob`) which has been [deprecated](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html), breaking authentication for gdrive with oauth. 

Switching to LocalWebserverAuth solves the issue (thanks @shcheklein)


fixed iterative/dvc#7867