### PR TITLE
gha: fix issue when caching virtual environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .nox
-        key: ${{ runner.os }}-${{ steps.setup-python.outputs.version }}-${{ hashFiles('noxfile.py') }}-nox
+        key: ${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('noxfile.py') }}-nox
 
     - name: cache pre-commit hook
       uses: actions/cache@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: Set up Python ${{ matrix.pyv }}
       uses: actions/setup-python@v4
+      id: setup-python
       with:
         python-version: ${{ matrix.pyv }}
         cache: pip
@@ -42,7 +43,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: .nox
-        key: ${{ runner.os }}-${{ matrix.pyv }}-${{ hashFiles('noxfile.py') }}_nox3
+        key: ${{ runner.os }}-${{ steps.setup-python.outputs.version }}-${{ hashFiles('noxfile.py') }}-nox
 
     - name: cache pre-commit hook
       uses: actions/cache@v3


### PR DESCRIPTION
Whenever the `setup-python` action would provide a new patch version of the python (as it happened with 3.10.4 -> 3.10.5), it'd break the caching of the virtual environment in the nox and would throw following (cryptic) error:

```
Error: python is not installed into the virtualenv, it is located at /opt/hostedtoolcache/Python/3.10.5/x64/bin/python. Pass external=True into run() to explicitly allow this.
```

It seems it's because the virtualenv has a broken symlink to the old interpreter that does not exist after the update.

https://github.com/actions/setup-python/issues/182 may be related.

With this change, the cache key now depends on the full python version instead of just major.minor. So this issue should hopefully not happen again, and automatically get invalidated.

Also see 855ea68887b4d, d4482b785040e and d6606c9fbcc.