### PR TITLE
transfer: add naive objects transfer function

### DIFF
--- a/src/dvc_objects/transfer.py
+++ b/src/dvc_objects/transfer.py
@@ -1,0 +1,25 @@
+from typing import TYPE_CHECKING, Set
+
+if TYPE_CHECKING:
+    from .db import ObjectDB
+
+
+def transfer(
+    src: "ObjectDB", dest: "ObjectDB", oids: Set["str"], jobs: int = None
+) -> Set["str"]:
+    src_exists = set(src.oids_exist(oids, jobs=jobs))
+    src_missing = oids - src_exists
+
+    dest_exists = set(dest.oids_exist(oids, jobs=jobs))
+    dest_missing = oids - dest_exists
+
+    missing = dest_missing & src_missing
+    new = src_exists - dest_exists
+
+    for oid in new:
+        path = src.oid_to_path(oid)
+        dest.add(path, src.fs, oid)
+
+    if missing:
+        raise Exception("missing objects", missing)
+    return new

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,11 @@
+from dvc_objects.db import ObjectDB
+from dvc_objects.transfer import transfer
+
+
+def test_transfer(memfs):
+    src = ObjectDB(memfs, "/odb1")
+    dest = ObjectDB(memfs, "/odb2")
+
+    src.add_bytes("1234", b"content")
+    assert transfer(src, dest, {"1234"}) == {"1234"}
+    assert dest.exists("1234")


### PR DESCRIPTION
This implements a very naive transfer mechanism without
batching (which should be a straightforward change after
we have batching in odb.add itself).