### PR TITLE
odb: introduce `add_bytes` API

### DIFF
--- a/src/dvc_objects/fs/base.py
+++ b/src/dvc_objects/fs/base.py
@@ -81,6 +81,10 @@ class FileSystem:
     def config(self) -> Dict[str, Any]:
         return self._config
 
+    @property
+    def root_marker(self) -> str:
+        return self.fs.root_marker
+
     @cached_property
     def path(self):
         from .path import Path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import requests
 from funcy import silent
 from upath import UPath
 
-from dvc_objects.fs.implementations.local import LocalFileSystem
+from dvc_objects.fs import LocalFileSystem, MemoryFileSystem
 
 
 def wait_until(pred, timeout: float, pause: float = 0.1):
@@ -96,3 +96,14 @@ def tmp_upath(request):
     elif param == "s3":
         return request.getfixturevalue("s3path")
     raise ValueError(f"unknown {param=}")
+
+
+@pytest.fixture(autouse=True)
+def memfs():
+    fs = MemoryFileSystem()
+    store = fs.fs.store
+    assert not store
+    try:
+        yield fs
+    finally:
+        store.clear()

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -1,0 +1,15 @@
+from io import BytesIO
+
+import pytest
+
+from dvc_objects.db import ObjectDB
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [(b"content", b"content"), (BytesIO(b"content"), b"content")],
+)
+def test_write(memfs, data, expected):
+    odb = ObjectDB(memfs)
+    odb.add_bytes("1234", data)
+    assert memfs.cat_file("/12/34") == expected


### PR DESCRIPTION
`write` is a low-level, *dumb* API to write the content with the `oid` as a key.

Makes it easier to setup odb for testing instead of doing `fs.pipe_file` + `odb.add()`. I think it is convenient to have this function instead of using two APIs.
