### PR TITLE
odb: add exists_prefix method

### DIFF
--- a/src/dvc_objects/db.py
+++ b/src/dvc_objects/db.py
@@ -47,6 +47,14 @@ class ObjectDB:
     def exists(self, oid: str) -> bool:
         return self.fs.exists(self.oid_to_path(oid))
 
+    def exists_prefix(self, short_oid: str) -> str:
+        ret = [oid for oid in self.all() if oid.startswith(short_oid)]
+        if not ret:
+            raise KeyError(short_oid)
+        if len(ret) == 1:
+            return ret[0]
+        raise ValueError(short_oid, ret)
+
     def move(self, from_info, to_info):
         self.fs.move(from_info, to_info)
 

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -57,7 +57,7 @@ def test_exists(memfs):
 def test_exists_prefix(memfs):
     odb = ObjectDB(memfs, "/odb")
     with pytest.raises(KeyError):
-        assert odb.exists_prefix("12")
+        assert odb.exists_prefix("123")
 
     odb.add_bytes("123456", b"content")
     assert odb.exists_prefix("123") == "123456"
@@ -68,8 +68,8 @@ def test_exists_prefix_ambiguous(memfs):
     odb.add_bytes("123456", b"content")
     odb.add_bytes("123450", b"content")
     with pytest.raises(ValueError) as exc:
-        assert odb.exists_prefix("12")
-    assert exc.value.args == ("12", ["123450", "123456"])
+        assert odb.exists_prefix("123")
+    assert exc.value.args == ("123", ["123450", "123456"])
 
 
 def test_move(memfs):

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -54,6 +54,24 @@ def test_exists(memfs):
     assert odb.exists("1234")
 
 
+def test_exists_prefix(memfs):
+    odb = ObjectDB(memfs, "/odb")
+    with pytest.raises(KeyError):
+        assert odb.exists_prefix("12")
+
+    odb.add_bytes("123456", b"content")
+    assert odb.exists_prefix("123") == "123456"
+
+
+def test_exists_prefix_ambiguous(memfs):
+    odb = ObjectDB(memfs, "/odb")
+    odb.add_bytes("123456", b"content")
+    odb.add_bytes("123450", b"content")
+    with pytest.raises(ValueError) as exc:
+        assert odb.exists_prefix("12")
+    assert exc.value.args == ("12", ["123450", "123456"])
+
+
 def test_move(memfs):
     odb = ObjectDB(memfs, "/")
     odb.add_bytes("1234", b"content")


### PR DESCRIPTION
Requires for testtool in dvc-data for supporting short_oid as an argument. I forgot to add in dvc-objects, thought I did.
It's not very optimal, but since we only require for one call in testtool, that should be fine.
https://github.com/iterative/dvc-data/commit/3e0362ac226ab0d0ff64ee1b778bb85fa681671c