### PR TITLE
Always set desc on Tqdm object

### DIFF
--- a/src/dvc_objects/_tqdm.py
+++ b/src/dvc_objects/_tqdm.py
@@ -100,6 +100,10 @@ class Tqdm(tqdm):
             total=total,
             **kwargs,
         )
+        
+        if not hasattr(self, "desc"):
+            self.desc = desc or ""
+            
         self.postfix = postfix or {"info": ""}
         if bar_format is None:
             if self.__len__():


### PR DESCRIPTION
In non-interactive environments, the `desc` property of the `tqdm` object [does not get set in the constructor](https://github.com/tqdm/tqdm/blob/4f208e72552c4d916aa4fe6a955349ee8b2ed353/tqdm/std.py#L984-L1005). This causes bug: https://github.com/iterative/dvc/issues/7896. I've also opened https://github.com/tqdm/tqdm/pull/1341 in case this fix should be made upstreams, but since this project depends on the existence of the `desc` property of the `tqdm` I figure it's also safe to set it here.