### PR TITLE
tests: use tmp_upath_factory from pytest-servers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ tests =
     pytest-mock==3.8.2
     pylint==2.14.4
     mypy==0.961
-    pytest-servers[s3]==0.0.5
+    pytest-servers[s3]==0.0.7
 
 all =
     %(azure)s

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
-from dvc_objects.fs import MemoryFileSystem
+from dvc_objects.fs import as_filesystem
 
 
-@pytest.fixture(autouse=True)
-def memfs():
-    return MemoryFileSystem(global_store=False)
+@pytest.fixture
+def memfs(memory_path):
+    yield as_filesystem(memory_path.fs)


### PR DESCRIPTION
fixes #91
