### PR TITLE
Configurable number of workers of ThreadPoolExecutor to fix some performance issues

### DIFF
--- a/src/dvc_objects/fs/base.py
+++ b/src/dvc_objects/fs/base.py
@@ -57,9 +57,9 @@ class FileSystem:
 
     protocol = "base"
     REQUIRES: ClassVar[Dict[str, str]] = {}
-    _JOBS = 4 * cpu_count()
+    _JOBS = int(os.environ.get("DVC_JOBS", 4 * cpu_count()))
 
-    HASH_JOBS = max(1, min(4, cpu_count() // 2))
+    HASH_JOBS = max(1, min(4, int(os.environ.get("DVC_JOBS", cpu_count() // 2))))
     LIST_OBJECT_PAGE_SIZE = 1000
     TRAVERSE_WEIGHT_MULTIPLIER = 5
     TRAVERSE_PREFIX_LEN = 2


### PR DESCRIPTION
Hi !

I noticed that our performance issues with DVC were related to the `ThreadPoolExecutor`. 
When I bypassed its init to force the number of workers to 1 (no multithreading), the execution time of the `dvc add folder` command (as well as other commands) fell from 20 minutes to about 20 seconds.

This could be a hardware problem on our end, but in any case, the number of workers was not easily customizable and the default values seemed rather arbitrary. Could something like an env variable find its way into your library, so that one could easily change this behavior without having to specify a --job argument for each command?