### PR TITLE
fs: gdrive: create temporary tmp_dir if not provided

### DIFF
--- a/src/dvc_objects/fs/implementations/gdrive.py
+++ b/src/dvc_objects/fs/implementations/gdrive.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import tempfile
 import threading
 
 from funcy import cached_property, wrap_prop
@@ -67,7 +68,8 @@ class GDriveFileSystem(FileSystem):  # pylint:disable=abstract-method
         self._validate_config()
 
         tmp_dir = config["gdrive_credentials_tmp_dir"]
-        assert tmp_dir
+        if not tmp_dir:
+            tmp_dir = tempfile.mkdtemp("dvc-gdrivefs")
 
         self._gdrive_service_credentials_path = tmp_fname(
             os.path.join(tmp_dir, "")


### PR DESCRIPTION
Temporary fix for https://github.com/iterative/dvc/issues/7984

Proper fix is to stop asking for tmp_dir completely and simplify auth
https://github.com/iterative/PyDrive2/issues/193