### PR TITLE
fs: gdrive: upgrade pydrive2 to 1.11.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ azure =
     adlfs>=2021.10.0
     azure-identity>=1.4.0
     knack
-gdrive = pydrive2[fsspec]>=1.10.2
+gdrive = pydrive2[fsspec]>=1.11.0
 gs = gcsfs>=2021.11.1
 hdfs =
     # due to https://github.com/python-poetry/poetry/issues/4683, we have to


### PR DESCRIPTION
Allows us to fully avoid saving `GDRIVE_CREDENTIALS_DATA` env into any files on disk. Everything is kept in-memory and is secure now.