### PR TITLE
fs: http: fix `isfile` method

### DIFF
--- a/src/dvc_objects/fs/implementations/http.py
+++ b/src/dvc_objects/fs/implementations/http.py
@@ -154,9 +154,6 @@ class HTTPFileSystem(FileSystem):
     def isdir(self, *args, **kwargs):
         return False
 
-    def isfile(self, *args, **kwargs):
-        return self.fs.isfile(*args, **kwargs)
-
     def ls(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/src/dvc_objects/fs/implementations/http.py
+++ b/src/dvc_objects/fs/implementations/http.py
@@ -155,7 +155,7 @@ class HTTPFileSystem(FileSystem):
         return False
 
     def isfile(self, *args, **kwargs):
-        return True
+        return self.fs.exists(*args, **kwargs)
 
     def ls(self, *args, **kwargs):
         raise NotImplementedError

--- a/src/dvc_objects/fs/implementations/http.py
+++ b/src/dvc_objects/fs/implementations/http.py
@@ -155,7 +155,7 @@ class HTTPFileSystem(FileSystem):
         return False
 
     def isfile(self, *args, **kwargs):
-        return self.fs.exists(*args, **kwargs)
+        return self.fs.isfile(*args, **kwargs)
 
     def ls(self, *args, **kwargs):
         raise NotImplementedError


### PR DESCRIPTION
This seemingly minor change fixes pushing data to an HTTP remote storage with `dvc` v2.16.0. At the moment, `dvc` v2.16.0 cannot push _any data at all_ to an HTTP remote storage!

I noticed that with `dvc` v2.15.0 pushing data to an HTTP remote storage works fine while it doesn't work - i.e. data just isn't transferred without an error - with v2.16.0. Between `dvc` v2.15.0 and v2.16.0, `dvc-objects` (a transitive dependency of `dvc` via `dvc-data`) was bumped from v0.1.5 to v0.1.6 by the bump of `dvc-data` from v0.1.5 to v0.1.6. After some digging, I arrived at `dvc-objects` and #114 which, among other changes, changed the implementation of the [`ObjectDB.exists(...)`](https://github.com/iterative/dvc-objects/blob/ebee28733103ac2b13c5207f640394ff03603699/src/dvc_objects/db.py#L45-L46) method:

```diff
 def exists(self, oid: str) -> bool:
-    return self.fs.exists(self.oid_to_path(oid))
+    return self.fs.isfile(self.oid_to_path(oid))
```

Now, [`FileSystem.exists(...)`](https://github.com/iterative/dvc-objects/blob/ebee28733103ac2b13c5207f640394ff03603699/src/dvc_objects/fs/base.py#L268-L269) simply delegates the call to the underlying `fsspec` filesystem implementation, but [`HTTPFileSystem.isfile(...)`](https://github.com/iterative/dvc-objects/blob/ebee28733103ac2b13c5207f640394ff03603699/src/dvc_objects/fs/implementations/http.py#L157-L158) overrides this delegation by a hardcoded return value `True` which makes the [`ObjectDB.exists(...)`](https://github.com/iterative/dvc-objects/blob/ebee28733103ac2b13c5207f640394ff03603699/src/dvc_objects/db.py#L45-L46) method always return `True` and prevents any data upload to an HTTP remote storage because every file is considered to exist already.