### PR TITLE
fs: http: do not timeout on sock_read

### DIFF
--- a/src/dvc_objects/fs/implementations/http.py
+++ b/src/dvc_objects/fs/implementations/http.py
@@ -117,7 +117,7 @@ class HTTPFileSystem(FileSystem):
             total=None,
             connect=self.REQUEST_TIMEOUT,
             sock_connect=self.REQUEST_TIMEOUT,
-            sock_read=self.REQUEST_TIMEOUT,
+            sock_read=None,
         )
 
         return RetryClient(**kwargs)


### PR DESCRIPTION
We have been getting reports that the timeout on sock_read was raising
timeout error even for chunked uploads, and sometimes even uploading
zero-byte files.

See: https://github.com/iterative/dvc/issues/8065
and https://github.com/iterative/dvc/issues/8100.

These kinds of logic don't belong here and should be upstreamed (eg: RetryClient/ClientTimeout, etc).
We added timeout in https://github.com/iterative/dvc/pull/7460 because of freezes in
https://github.com/iterative/dvc/issues/7414.

I think we can rollback this for now given that there are lots of report of failures/issues with this line,
and if we get any new reports of hangs, we'll investigate it separately.