### PR TITLE
fs: generic: handle linux ENOTTY in _try_links

### DIFF
--- a/src/dvc_objects/fs/generic.py
+++ b/src/dvc_objects/fs/generic.py
@@ -67,7 +67,12 @@ def _try_links(
         try:
             return _link(link, from_fs, from_path, to_fs, to_path)
         except OSError as exc:
-            if exc.errno not in [errno.EPERM, errno.ENOTSUP, errno.EXDEV]:
+            if exc.errno not in (
+                errno.EPERM,
+                errno.ENOTSUP,
+                errno.EXDEV,
+                errno.ENOTTY,
+            ):
                 raise
             error = exc
 


### PR DESCRIPTION
Linux can return ENOTTY (25) on `ioctl` calls for devices that don't implement the requested ioctl type, so we need to include it in the set of expected errnos when trying to reflink.

https://man7.org/linux/man-pages/man2/ioctl.2.html

Will fix iterative/dvc#6980