### PR TITLE
ssh: Decouple `password` and `passphrase`.

### DIFF
--- a/src/dvc_objects/fs/implementations/ssh.py
+++ b/src/dvc_objects/fs/implementations/ssh.py
@@ -67,9 +67,8 @@ class SSHFileSystem(FileSystem):
             config["password"] = ask_password(
                 login_info["host"], login_info["username"], login_info["port"]
             )
-
         login_info["password"] = config.get("password")
-        login_info["passphrase"] = config.get("password")
+        login_info["passphrase"] = config.get("passphrase")
 
         raw_keys = []
         if config.get("keyfile"):


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc/issues/8137

See https://github.com/iterative/dvc/issues/8137#issuecomment-1218341188

Need to add test in `dvc-ssh`