### PR TITLE
deps: don't install/depend on dvc plugins

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,31 +41,8 @@ tests =
     mypy==0.971
     pytest-servers[s3]==0.0.8
 
-all =
-    %(azure)s
-    %(gdrive)s
-    %(gs)s
-    %(hdfs)s
-    %(http)s
-    %(oss)s
-    %(s3)s
-    %(ssh)s
-    %(webdav)s
-    %(webhdfs)s
-azure = dvc-azure
-gdrive = dvc-gdrive
-gs = dvc-gs
-hdfs = dvc-hdfs; implementation_name=='cpython'
-http = dvc-http
-oss = dvc-oss
-s3 = dvc-s3
-ssh = dvc-ssh
-webdav = dvc-webdav
-# not to break `dvc[webhdfs]`
-webhdfs = dvc-webhdfs>=0.0.2; implementation_name=='cpython'
 dev =
     %(tests)s
-    %(all)s
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
We no longer test these and they are really `dvc` (and not `dvc-objects`) plugins that will be registered through `dvc`.