### PR TITLE
fs: version_aware: use fs_args instead of fs

### DIFF
--- a/src/dvc_objects/fs/base.py
+++ b/src/dvc_objects/fs/base.py
@@ -111,7 +111,7 @@ class FileSystem:
 
     @cached_property
     def version_aware(self) -> bool:
-        return getattr(self.fs, "version_aware", False)
+        return self.fs_args.get("version_aware", False)
 
     @staticmethod
     def _get_kwargs_from_urls(urlpath: str) -> "Dict[str, Any]":


### PR DESCRIPTION
This avoids creating an fs instance.