### PR TITLE
Revert "db: introduce init() to pre-create odb structure"

### DIFF
--- a/src/dvc_objects/db.py
+++ b/src/dvc_objects/db.py
@@ -42,13 +42,6 @@ class ObjectDB:
     def __hash__(self):
         return hash((self.fs.protocol, self.path))
 
-    def init(self):
-        if self.read_only:
-            return
-
-        for num in range(0, 256):
-            self.makedirs(self.fs.path.join(self.path, f"{num:x}"))
-
     def exists(self, oid: str) -> bool:
         return self.fs.isfile(self.oid_to_path(oid))
 
@@ -97,6 +90,8 @@ class ObjectDB:
             size = cast("Optional[int]", getattr(fobj, "size", None))
 
         path = self.oid_to_path(oid)
+        parent = self.fs.path.parent(path)
+        self.makedirs(parent)
         self.fs.put_file(fobj, path, size=size)
 
     def add(
@@ -123,6 +118,7 @@ class ObjectDB:
             desc=fs.path.name(path),
             bytes=True,
         ) as cb:
+            self.makedirs(self.fs.path.parent(cache_path))
             generic.transfer(
                 fs,
                 path,

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -17,28 +17,18 @@ def test_odb(memfs):
     assert hash(odb) == hash(odb)
 
 
-def test_odb_init(memfs):
-    odb = ObjectDB(memfs, "/odb")
-    dirs = [memfs.path.join(odb.path, f"{num:x}") for num in range(0, 256)]
-    assert not memfs.exists(odb.path)
-    odb.init()
-    assert set(dirs) == set(memfs.ls(odb.path, detail=False))
-
-
 @pytest.mark.parametrize(
     "data, expected",
     [(b"contents", b"contents"), (BytesIO(b"contents"), b"contents")],
 )
 def test_add_bytes(memfs, data, expected):
     odb = ObjectDB(memfs, memfs.root_marker)
-    odb.init()
     odb.add_bytes("1234", data)
     assert memfs.cat_file("/12/34") == expected
 
 
 def test_odb_readonly():
     odb = ObjectDB(FileSystem(), "/odb", read_only=True)
-    odb.init()
     with pytest.raises(ObjectDBPermissionError):
         odb.add("/odb/foo", odb.fs, "1234")
 
@@ -50,7 +40,6 @@ def test_odb_add(memfs):
     memfs.pipe({"foo": b"foo", "bar": b"bar"})
 
     odb = ObjectDB(memfs, "/odb")
-    odb.init()
     odb.add("/foo", memfs, "1234")
     assert odb.exists("1234")
 
@@ -61,14 +50,12 @@ def test_odb_add(memfs):
 
 def test_exists(memfs):
     odb = ObjectDB(memfs, "/odb")
-    odb.init()
     odb.add_bytes("1234", b"content")
     assert odb.exists("1234")
 
 
 def test_exists_prefix(memfs):
     odb = ObjectDB(memfs, "/odb")
-    odb.init()
     with pytest.raises(KeyError):
         assert odb.exists_prefix("123")
 
@@ -87,7 +74,6 @@ def test_exists_prefix(memfs):
 )
 def test_exists_prefix_ambiguous(memfs, oid, found):
     odb = ObjectDB(memfs, "/odb")
-    odb.init()
     odb.add_bytes("123456", b"content")
     odb.add_bytes("123450", b"content")
 
@@ -98,7 +84,6 @@ def test_exists_prefix_ambiguous(memfs, oid, found):
 
 def test_move(memfs):
     odb = ObjectDB(memfs, "/")
-    odb.init()
     odb.add_bytes("1234", b"content")
     odb.move("/12/34", "/45/67")
     assert list(memfs.find("")) == ["/45/67"]
@@ -149,7 +134,6 @@ def test_listing_oids(memfs, mocker, traverse):
     assert not list(odb.list_oids_exists(oids))
     assert not odb.oids_exist(oids)
 
-    odb.init()
     odb.add_bytes("123456", b"content")
     assert list(odb.all()) == ["123456"]
     assert list(odb.list_oids_exists(oids))


### PR DESCRIPTION
Reverts iterative/dvc-objects#145

See https://github.com/iterative/dvc-objects/pull/145#discussion_r973010258