### PR TITLE
odb: add detele/clear methods

### DIFF
--- a/src/dvc_objects/db.py
+++ b/src/dvc_objects/db.py
@@ -142,6 +142,13 @@ class ObjectDB:
                 callback=Callback.as_callback(cb),
             )
 
+    def delete(self, oid: str):
+        self.fs.remove(self.oid_to_path(oid))
+
+    def clear(self):
+        for oid in self.all():
+            self.delete(oid)
+
     def _oid_parts(self, oid: str) -> Tuple[str, str]:
         return oid[:2], oid[2:]
 

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -48,6 +48,42 @@ def test_odb_add(memfs):
     assert memfs.cat_file("/odb/12/34") == b"foo"
 
 
+def test_delete(memfs):
+    memfs.pipe({"foo": b"foo", "bar": b"bar"})
+
+    odb = ObjectDB(memfs, "/odb")
+    odb.add("/foo", memfs, "1234")
+    odb.add("/bar", memfs, "4321")
+    assert odb.exists("1234")
+    assert odb.exists("4321")
+
+    odb.delete("1234")
+    assert memfs.isdir("/odb/12")
+    assert memfs.isdir("/odb/43")
+    assert not odb.exists("1234")
+    assert odb.exists("4321")
+
+    odb.delete("4321")
+    assert memfs.isdir("/odb/12")
+    assert memfs.isdir("/odb/43")
+    assert not odb.exists("1234")
+    assert not odb.exists("4321")
+
+
+def test_clear(memfs):
+    memfs.pipe({"foo": b"foo", "bar": b"bar"})
+
+    odb = ObjectDB(memfs, "/odb")
+    odb.add("/foo", memfs, "1234")
+    odb.add("/bar", memfs, "4321")
+
+    odb.clear()
+    assert memfs.isdir("/odb/12")
+    assert memfs.isdir("/odb/43")
+    assert not odb.exists("1234")
+    assert not odb.exists("4321")
+
+
 def test_exists(memfs):
     odb = ObjectDB(memfs, "/odb")
     odb.add_bytes("1234", b"content")


### PR DESCRIPTION
Mostly convenience, to avoid manually messing with odb.fs.