### PR TITLE
db: use fs.path.name instead of fs.path.basename

### DIFF
--- a/src/dvc_objects/db.py
+++ b/src/dvc_objects/db.py
@@ -55,7 +55,7 @@ class ObjectDB:
         existing = set()
         with suppress(FileNotFoundError):
             existing = {
-                self.fs.path.basename(path)
+                self.fs.path.name(path)
                 for path in self.fs.ls(self.path, detail=False)
             }
 


### PR DESCRIPTION
The latter is not available everywhere.