### PR TITLE
localfs: remove urlsplit from path.normpath

### DIFF
--- a/src/dvc_objects/fs/local.py
+++ b/src/dvc_objects/fs/local.py
@@ -187,9 +187,11 @@ class LocalFileSystem(FileSystem):
 
     @cached_property
     def path(self):
-        from .path import Path
+        from .path import LocalFileSystemPath
 
-        return Path(self.sep, getcwd=os.getcwd, realpath=os.path.realpath)
+        return LocalFileSystemPath(
+            self.sep, getcwd=os.getcwd, realpath=os.path.realpath
+        )
 
     def upload_fobj(self, fobj, to_info, **kwargs):
         self.makedirs(self.path.parent(to_info))

--- a/src/dvc_objects/fs/path.py
+++ b/src/dvc_objects/fs/path.py
@@ -144,3 +144,8 @@ class Path:
 
     def as_posix(self, path: str) -> str:
         return path.replace(self.flavour.sep, posixpath.sep)
+
+
+class LocalFileSystemPath(Path):
+    def normpath(self, path: str) -> str:
+        return self.flavour.normpath(path)

--- a/tests/fs/test_localfs.py
+++ b/tests/fs/test_localfs.py
@@ -119,3 +119,12 @@ def test_walk_detail(dir_path):
                 exp_root, basename
             )
             assert files[basename]["type"] == "file"
+
+
+@pytest.mark.skipif(
+    os.name == "nt", reason="A file name can't contain newlines on Windows"
+)
+def test_normpath_with_newlines():
+    fs = LocalFileSystem()
+    newline_path = os.path.join("one", "two\nthree")
+    assert fs.path.normpath(newline_path) == newline_path


### PR DESCRIPTION
Fixes https://github.com/iterative/dvc-objects/issues/177

`LocalFileSystem.path.normpath` was overriden to avoid using `urlsplit/urlunsplit`. This enables us to perform  `dvc add` for filenames with special characters not valid in URLs.

Related RPs: https://github.com/iterative/dvc/pull/8778
