### PR TITLE
fs: add batch utils.exists implementaiton

### DIFF
--- a/src/dvc_objects/fs/base.py
+++ b/src/dvc_objects/fs/base.py
@@ -394,15 +394,19 @@ class FileSystem:
         return not (self.is_symlink(path) or self.is_hardlink(path))
 
     @overload
-    def ls(self, path: AnyFSPath, detail: Literal[True]) -> "Iterator[Entry]":
+    def ls(
+        self, path: AnyFSPath, detail: Literal[True], **kwargs
+    ) -> "Iterator[Entry]":
         ...
 
     @overload
-    def ls(self, path: AnyFSPath, detail: Literal[False]) -> Iterator[str]:
+    def ls(
+        self, path: AnyFSPath, detail: Literal[False], **kwargs
+    ) -> Iterator[str]:
         ...
 
     def ls(self, path, detail=False, **kwargs):
-        return self.fs.ls(path, detail=detail)
+        return self.fs.ls(path, detail=detail, **kwargs)
 
     def find(
         self,


### PR DESCRIPTION
Adds naive `fs.utils.exists` implementation for querying batched file existence. Essentially it is a dumbed down and much less optimized alternative to what we do for querying ODB status.

For `version_aware` remotes, on `push` we need to check whether or not version IDs that we have in the .dvc file still exist in the remote (old object versions could have been removed from the bucket for a variety of reasons). If the version ID we have no longer exists, we should push the object again and update the .dvc file with the new version ID.

To check this existence we have two options:

1. Check existence using `fs.exists()` for each file we have to push
2. Use `fs.ls(<parent dir(s)>, versions=True)` calls and get a listing of all object versions in a given directory (and then compare that list with the list of files we need to check)

This presents the same problem we have w/regular remotes: Option 1 is faster when we have a relatively small number of files/versions to check and a bucket with a relatively large number of object versions. Option 2 is faster when we have a relatively large number of versions to check and a relatively small number of versions in the bucket.

For regular remotes we know the remote structure is evenly distributed according to md5 prefixes and can make an actual estimate as to which method will be faster, but for cloud versioning we have no idea what the dir structure of the remote looks like, and have no idea how many versions there will be for any given object in the remote. So essentially we cannot know beforehand which option to use when checking status for cloud versioned remotes.

This PR goes with the simplest solution I could think of and just does both operations in parallel until we have gotten a result for all the paths we are looking for.

related: https://github.com/iterative/dvc/issues/8774