### PR TITLE
fs.get_missing_deps: use find_spec to check if packages are missing instead of importing them

### DIFF
--- a/src/dvc_objects/fs/base.py
+++ b/src/dvc_objects/fs/base.py
@@ -134,16 +134,9 @@ class FileSystem:
 
     @classmethod
     def get_missing_deps(cls) -> List[str]:
-        import importlib
+        from importlib.util import find_spec
 
-        missing: List[str] = []
-        for package, module in cls.REQUIRES.items():
-            try:
-                importlib.import_module(module)
-            except ImportError:
-                missing.append(package)
-
-        return missing
+        return [pkg for pkg, mod in cls.REQUIRES.items() if not find_spec(mod)]
 
     def _check_requires(self, **kwargs):
         from .scheme import Schemes


### PR DESCRIPTION
This speeds up `dvc version` from >1s to ~0.35s in my machine.
See https://docs.python.org/3/library/importlib.html#checking-if-a-module-can-be-imported.