### PR TITLE
warn on incompatible fsspec installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires=
     funcy>=1.14
     fsspec>=2022.10.0
     typing-extensions>=3.7.4
+    packaging>=19
 
 [options.extras_require]
 tests =

--- a/src/dvc_objects/fs/base.py
+++ b/src/dvc_objects/fs/base.py
@@ -22,7 +22,7 @@ from typing import (
 )
 
 from fsspec.asyn import get_loop
-from funcy import cached_property, once
+from funcy import cached_property, once_per_args
 
 from ..executors import ThreadPoolExecutor, batch_coros
 from .callbacks import DEFAULT_CALLBACK, Callback
@@ -58,7 +58,7 @@ class LinkError(OSError):
         )
 
 
-@once
+@once_per_args
 def check_required_version(
     pkg: str, dist: str = "dvc_objects", log_level=logging.WARNING
 ):


### PR DESCRIPTION
```console
$ dvc data status
WARNING: 'fsspec>=2022.10.0' is required, but you have '2022.8.2' installed which is incompatible.
ERROR: unexpected error - 'ino'
```