### PR TITLE
transfer: callback: do not set sizes, do it in odb.add()

### DIFF
--- a/src/dvc_objects/db.py
+++ b/src/dvc_objects/db.py
@@ -172,6 +172,9 @@ class ObjectDB:
 
         from_paths, to_oids = zip(*to_add)
         jobs: Optional[int] = kwargs.get("batch_size", kwargs.get("jobs"))
+
+        callback.set_size(len(from_paths))
+
         generic.transfer(
             fs,
             list(from_paths),

--- a/src/dvc_objects/fs/generic.py
+++ b/src/dvc_objects/fs/generic.py
@@ -288,7 +288,6 @@ def transfer(
     else:
         links = links or ["reflink", "copy"]
 
-    callback.set_size(len(from_path))
     # Try to link files sequentially. If/when the only remaining link type is
     # copy, the remaining copy operations will be batched.
     for i, (from_p, to_p) in enumerate(zip(from_path, to_path)):


### PR DESCRIPTION
The transfer() api should not set sizes, as it's a responsibility of the caller. `transfer()` could be called with just one file to transfer, so a callback of size 1 does not make sense.

This broke `checkout` as it checks out one by one.

Related https://github.com/iterative/dvc/issues/6226.

Current dependencies on/for this PR:

- https://github.com/iterative/dvc-objects/pull/208 👈🏼 
    - https://github.com/iterative/dvc-data/pull/355
        - https://github.com/iterative/dvc/pull/9445