### PR TITLE
odb: verify that parts len is actually 2

### DIFF
--- a/src/dvc_objects/db.py
+++ b/src/dvc_objects/db.py
@@ -216,7 +216,8 @@ class ObjectDB:
         yield from self.fs.find(paths, batch_size=jobs, prefix=prefix)
 
     def path_to_oid(self, path) -> str:
-        parts = self.fs.path.parts(path)[-2:]
+        self_parts = self.fs.path.parts(self.path)
+        parts = self.fs.path.parts(path)[len(self_parts) :]
 
         if not (len(parts) == 2 and parts[0] and len(parts[0]) == 2):
             raise ValueError(f"Bad cache file path '{path}'")

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -143,10 +143,16 @@ def test_get(memfs):
 def test_path_to_oid():
     odb = ObjectDB(FileSystem(), "/odb")
 
-    assert odb.path_to_oid("/12/34") == "1234"
+    with pytest.raises(ValueError):
+        assert odb.path_to_oid("/12/34") == "1234"
+
     assert odb.path_to_oid("/odb/12/34") == "1234"
-    assert odb.path_to_oid("/odb/12/34/56") == "3456"
-    assert odb.path_to_oid("/odb/12/34/abcde12") == "34abcde12"
+
+    with pytest.raises(ValueError):
+        assert odb.path_to_oid("/odb/12/34/56")
+
+    with pytest.raises(ValueError):
+        assert odb.path_to_oid("/odb/12/34/abcde12")
 
     with pytest.raises(ValueError):
         odb.path_to_oid("bar")
@@ -247,7 +253,7 @@ def test_list_prefixes(mocker):
 def test_list_oids(mocker):
     # large remote, large local
     odb = ObjectDB(FileSystem(), "/odb")
-    mocker.patch.object(odb, "_list_prefixes", return_value=["12/34", "bar"])
+    mocker.patch.object(odb, "_list_prefixes", return_value=["/odb/12/34", "/odb/bar"])
     assert list(odb._list_oids()) == ["1234"]
 
 


### PR DESCRIPTION
Fixes bug where listing objects in DVC 2.x cache would include nonexistent paths due to 3.x hashes returned by `find()`

(previously it would only check the last 2 parts of a path, so `files/<md5>` still matched even when we were in the 2.x ODB)