### PR TITLE
ObjectDB._init: Ensure `self.fs.ls` return is not None before iterating.

### DIFF
--- a/src/dvc_objects/db.py
+++ b/src/dvc_objects/db.py
@@ -62,10 +62,9 @@ class ObjectDB:
         if self._dirs is None:
             self._dirs = set()
             with suppress(FileNotFoundError, NotImplementedError):
-                self._dirs = {
-                    self.fs.path.name(path)
-                    for path in self.fs.ls(self.path, detail=False)
-                }
+                paths = self.fs.ls(self.path, detail=False)
+                if paths:
+                    self._dirs = {self.fs.path.name(path) for path in paths}
 
         if dname in self._dirs:
             return

--- a/tests/test_odb.py
+++ b/tests/test_odb.py
@@ -48,6 +48,16 @@ def test_odb_add(memfs):
     assert memfs.cat_file("/odb/12/34") == b"foo"
 
 
+def test_odb_add_when_ls_returns_none(memfs, mocker):
+    """https://github.com/iterative/dvc/issues/9607"""
+    memfs.pipe({"foo": b"foo", "bar": b"bar"})
+    mocker.patch.object(memfs, "ls", return_value=None)
+
+    odb = ObjectDB(memfs, "/odb")
+    odb.add("/foo", memfs, "1234")
+    assert odb.exists("1234")
+
+
 def test_delete(memfs):
     memfs.pipe({"foo": b"foo", "bar": b"bar"})
 


### PR DESCRIPTION
Per https://github.com/iterative/dvc/issues/9607