### PR TITLE
Patch path names with [] for fsspec globbing

### DIFF
--- a/src/dvc_objects/fs/base.py
+++ b/src/dvc_objects/fs/base.py
@@ -136,25 +136,6 @@ class FileSystem:
     def unstrip_protocol(self, path: str) -> str:
         return path
 
-    def _patch_glob(
-        self,
-        from_info: str,
-        to_info: str,
-        from_infos: List[str],
-    ) -> Tuple[List[str], List[str]]:
-        from .local import localfs
-
-        patched_from_infos = [path.replace("[", "*") for path in from_infos]
-
-        to_infos = [
-            localfs.path.join(
-                to_info, *self.path.relparts(info.replace("*", "["), from_info)
-            )
-            for info in from_infos
-        ]
-
-        return patched_from_infos, to_infos
-
     @cached_property
     def fs(self) -> "AbstractFileSystem":  # pylint: disable=method-hidden
         raise NotImplementedError
@@ -656,11 +637,13 @@ class FileSystem:
                 return get_file(from_info, to_info)
 
             from_infos = list(self.find(from_info))
-
             if not from_infos:
                 return localfs.makedirs(to_info, exist_ok=True)
-            else:
-                from_infos, to_infos = self._patch_glob(from_info, to_info, from_infos)
+
+            to_infos = [
+                localfs.path.join(to_info, *self.path.relparts(info, from_info))
+                for info in from_infos
+            ]
 
         jobs = batch_size or self.jobs
         if self.fs.async_impl:


### PR DESCRIPTION
Fixes iterative/dvc#8964. The problem arising here is that `fsspec` uses its own globbing implementation. File names with `[]` inside are thus treated as special characters for globbing. When downloading files with `dvc` via `import-url`, it calls the `get` method on the `FileSystem` object with already resolved file names from the s3 bucket. At this point, there is no need to pass globbing with special characters to the `fsspec` again. Therefore I propose to exchange the `[` character temporarily with the `*` and then swap it back for destination file names. Another option would be to use the `glob.escape()` function - but this yields to escaped target file names like `/my/file[[]1]` after downloading. 