### PR TITLE
fs: transfer: don't raise if link failed with EINVAL

### DIFF
--- a/src/dvc_objects/fs/generic.py
+++ b/src/dvc_objects/fs/generic.py
@@ -257,6 +257,7 @@ def _try_links(
                 errno.EXDEV,
                 errno.ENOTTY,
                 errno.ENOSYS,
+                errno.EINVAL,
             ):
                 raise
             error = exc


### PR DESCRIPTION
Running into this on windows when working on a mapped network share https://support.microsoft.com/en-us/windows/map-a-network-drive-in-windows-29ce55d1-34e3-a7e2-4801-131475f9557d

The error I'm getting is:

```
OSError: [WinError 1] Incorrect function
```

which is mapped https://github.com/python/cpython/blob/5113ed7a2b92e8beabebe5fe2f6e856c52fbe1a0/PC/errmap.h#L132 to `EINVAL`.

Related to https://github.com/iterative/dvc/pull/9780