### PR TITLE
Fix pylint warning.

### DIFF
--- a/src/dvc_objects/fs/local.py
+++ b/src/dvc_objects/fs/local.py
@@ -15,7 +15,7 @@ from .utils import copyfile, makedirs, move, remove, tmp_fname
 logger = logging.getLogger(__name__)
 
 
-# pylint:disable=abstract-method, arguments-differ
+# pylint:disable=abstract-method, arguments-differ, arguments-renamed
 class FsspecLocalFileSystem(fsspec.AbstractFileSystem):
     sep = os.sep
 


### PR DESCRIPTION
To fix https://github.com/iterative/dvc-objects/actions/runs/6162702142/job/16724739641#step:5:72Ç

Do we care about respecting the reference implementation? Should we add and honor the `on_error` arg instead?