### PR TITLE
generic: transfer: check if links are empty

### DIFF
--- a/src/dvc_objects/fs/generic.py
+++ b/src/dvc_objects/fs/generic.py
@@ -316,7 +316,7 @@ def transfer(
     # Try to link files sequentially. If/when the only remaining link type is
     # copy, the remaining copy operations will be batched.
     for i, (from_p, to_p) in enumerate(zip(from_path, to_path)):
-        if links[0] == "copy":
+        if links and links[0] == "copy":
             copy(
                 from_fs,
                 from_path[i:],


### PR DESCRIPTION
Otherwise we might run into `IndexError: list index out of range` if none link types are supported and we use on_error.