### PR TITLE
fs: copy: limit to 1 job for localfs to localfs transfers

### DIFF
--- a/src/dvc_objects/executors.py
+++ b/src/dvc_objects/executors.py
@@ -45,10 +45,15 @@ class ThreadPoolExecutor(futures.ThreadPoolExecutor):
         It does not create all the futures at once to reduce memory usage.
         """
 
+        it = zip(*iterables)
+        if self.max_workers == 1:
+            for args in it:
+                yield fn(*args)
+            return
+
         def create_taskset(n: int) -> Set[futures.Future]:
             return {self.submit(fn, *args) for args in islice(it, n)}
 
-        it = zip(*iterables)
         tasks = create_taskset(self.max_workers * 5)
         while tasks:
             done, tasks = futures.wait(tasks, return_when=futures.FIRST_COMPLETED)

--- a/src/dvc_objects/fs/generic.py
+++ b/src/dvc_objects/fs/generic.py
@@ -86,7 +86,7 @@ def copy(
             to_fs,
             to_path,
             callback=callback,
-            batch_size=batch_size,
+            batch_size=1 if isinstance(to_fs, LocalFileSystem) else batch_size,
             on_error=on_error,
         )
     if isinstance(to_fs, LocalFileSystem):


### PR DESCRIPTION
More jobs is not better for localfs transfers. Even just using ThreadPoolExecutor with 1 job is already a significant penalty vs no pool at all.

There will be more details and high-level benchmark results in https://github.com/iterative/dvc/issues/9914

Related https://github.com/iterative/dvc-objects/pull/229
Related https://github.com/iterative/dvc/issues/9914