### PR TITLE
microopt: reorder to remove assertions, lazy imports

### DIFF
--- a/tests/benchmarks/test_fs.py
+++ b/tests/benchmarks/test_fs.py
@@ -1,15 +1,18 @@
 import errno
-import pytest
 import shutil
+
+import pytest
 from reflink import reflink as pyreflink
 from reflink.error import ReflinkImpossibleError
-from dvc_objects.fs.system import reflink, hardlink, symlink
+
+from dvc_objects.fs.system import hardlink, reflink, symlink
 
 NLINKS = 10000
 
 
 @pytest.mark.parametrize(
-    "link", [pytest.param(pyreflink, id="pyreflink"), reflink, hardlink, symlink]
+    "link",
+    [pytest.param(pyreflink, id="pyreflink"), reflink, hardlink, symlink],
 )
 def test_link(benchmark, tmp_path, link):
     (tmp_path / "original").mkdir()

--- a/tests/test_reflink.py
+++ b/tests/test_reflink.py
@@ -1,4 +1,5 @@
 import errno
+import os
 import stat
 from os import fspath, umask
 from pathlib import Path
@@ -37,12 +38,12 @@ def test_reflink(test_dir):
     assert stat_mode == (0o666 & ~umask(0))
 
 
+@pytest.mark.skipif(os.name != "nt", reason="only run in Windows")
 def test_reflink_unsupported_on_windows(test_dir, mocker):
     src = test_dir / "source"
     dest = test_dir / "dest"
     src.write_bytes(b"content")
 
-    mocker.patch("platform.system", mocker.MagicMock(return_value="Windows"))
     with pytest.raises(OSError) as exc:
         reflink(fspath(src), fspath(dest))
 


### PR DESCRIPTION
```
test_link[_reflink]      1.3341 (1.0)      1.3341 (1.0)      1.3341 (1.0)      0.0000 (1.0)      1.3341 (1.0)      0.0000 (1.0)           0;0  0.7496 (1.0)           1           1
test_link[pyreflink]     1.4004 (1.05)     1.4004 (1.05)     1.4004 (1.05)     0.0000 (1.0)      1.4004 (1.05)     0.0000 (1.0)           0;0  0.7141 (0.95)          1           1
test_link[reflink]       1.6404 (1.23)     1.6404 (1.23)     1.6404 (1.23)     0.0000 (1.0)      1.6404 (1.23)     0.0000 (1.0)           0;0  0.6096 (0.81)          1           1
```


Only `chmod` is a problem.


Internal reflink is now 5% faster than pyreflink.


- Simplify code, remove unnecessary assertions, and makes import eager.