### PR TITLE
bench: use .pytest_cache as tmpdir for running benchmarks

### DIFF
--- a/src/dvc_objects/fs/system.py
+++ b/src/dvc_objects/fs/system.py
@@ -100,10 +100,7 @@ elif sys.platform == "linux":
 else:
 
     def reflink(src, dst):
-        raise OSError(
-            errno.ENOTSUP,
-            f"reflink is not supported on '{sys.platform}'",
-        )
+        raise OSError(errno.ENOTSUP, "reflink is not supported")
 
 
 def inode(path: "AnyFSPath") -> int:

--- a/tests/benchmarks/test_fs.py
+++ b/tests/benchmarks/test_fs.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from reflink import ReflinkImpossibleError
 from reflink import reflink as pyreflink
 
 from dvc_objects.fs.system import hardlink, reflink, symlink
@@ -22,7 +23,7 @@ def test_link(benchmark, tmp_dir_pytest_cache, link):
     (original / "test").write_text("test")
     try:
         link(os.fspath(original / "test"), os.fspath(links / "test"))
-    except (OSError, NotImplementedError) as exc:
+    except (OSError, NotImplementedError, ReflinkImpossibleError) as exc:
         pytest.skip(reason=f"not supported: {exc}")
 
     paths = []

--- a/tests/benchmarks/test_fs.py
+++ b/tests/benchmarks/test_fs.py
@@ -1,45 +1,43 @@
-import errno
-import shutil
+import os
 
 import pytest
 from reflink import reflink as pyreflink
-from reflink.error import ReflinkImpossibleError
 
 from dvc_objects.fs.system import hardlink, reflink, symlink
 
-NLINKS = 10000
+NLINKS = 1000
 
 
 @pytest.mark.parametrize(
     "link",
     [pytest.param(pyreflink, id="pyreflink"), reflink, hardlink, symlink],
 )
-def test_link(benchmark, tmp_path, link):
-    (tmp_path / "original").mkdir()
+def test_link(benchmark, tmp_dir_pytest_cache, link):
+    original = tmp_dir_pytest_cache / "original"
+    original.mkdir()
 
+    links = tmp_dir_pytest_cache / "links"
+    links.mkdir()
+
+    (original / "test").write_text("test")
+    try:
+        reflink(original / "test", links / "test")
+    except OSError as exc:
+        pytest.skip(reason=f"reflink not supported: {exc}")
+
+    paths = []
     for idx in range(NLINKS):
-        (tmp_path / "original" / str(idx)).write_text(str(idx))
+        path = original / str(idx)
+        path.write_text(path.name)
+        paths.append((os.fspath(path), os.fspath(links / path.name)))
 
-    def _setup():
-        try:
-            shutil.rmtree(tmp_path / "links")
-        except FileNotFoundError:
-            pass
+    def setup():
+        for link in links.iterdir():
+            if link.is_file():
+                link.unlink()
 
-        (tmp_path / "links").mkdir()
+    def _link(paths):
+        for src, path in paths:
+            link(src, path)
 
-    original = str(tmp_path / "original")
-    links = str(tmp_path / "links")
-
-    def _link():
-        for idx in range(NLINKS):
-            try:
-                link(f"{original}/{idx}", f"{links}/{idx}")
-            except Exception as exc:
-                if isinstance(exc, (ReflinkImpossibleError, NotImplementedError)) or (
-                    isinstance(exc, OSError) and exc.errno == errno.ENOTSUP
-                ):
-                    pytest.skip(str(exc))
-                raise
-
-    benchmark.pedantic(_link, setup=_setup)
+    benchmark.pedantic(_link, args=(paths,), setup=setup, rounds=10, warmup_rounds=3)

--- a/tests/benchmarks/test_fs.py
+++ b/tests/benchmarks/test_fs.py
@@ -21,9 +21,9 @@ def test_link(benchmark, tmp_dir_pytest_cache, link):
 
     (original / "test").write_text("test")
     try:
-        reflink(original / "test", links / "test")
-    except OSError as exc:
-        pytest.skip(reason=f"reflink not supported: {exc}")
+        link(os.fspath(original / "test"), os.fspath(links / "test"))
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(reason=f"not supported: {exc}")
 
     paths = []
     for idx in range(NLINKS):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 import pytest
 
 from dvc_objects.fs.memory import MemoryFileSystem
@@ -6,3 +9,16 @@ from dvc_objects.fs.memory import MemoryFileSystem
 @pytest.fixture(autouse=True)
 def memfs():
     return MemoryFileSystem(global_store=False)
+
+
+@pytest.fixture
+def tmp_dir_pytest_cache(request):
+    """Create a test directory within cache directory.
+
+    The cache directory by default, is in the root of the repo, where reflink
+    may be supported.
+    """
+    cache = request.config.cache
+    path = cache.mkdir("dvc_objects_tests")
+    with TemporaryDirectory(dir=path) as tmp_dir:
+        yield Path(tmp_dir)

--- a/tests/test_reflink.py
+++ b/tests/test_reflink.py
@@ -25,7 +25,7 @@ def test_reflink(tmp_dir_pytest_cache):
 
 @pytest.mark.skipif(os.name != "nt", reason="only run in Windows")
 def test_reflink_unsupported_on_windows(tmp_dir_pytest_cache):
-    src = tmp_dir_pytest_cache/ "source"
+    src = tmp_dir_pytest_cache / "source"
     dest = tmp_dir_pytest_cache / "dest"
     src.write_bytes(b"content")
 

--- a/tests/test_reflink.py
+++ b/tests/test_reflink.py
@@ -24,9 +24,9 @@ def test_reflink(tmp_dir_pytest_cache):
 
 
 @pytest.mark.skipif(os.name != "nt", reason="only run in Windows")
-def test_reflink_unsupported_on_windows(test_dir, mocker):
-    src = test_dir / "source"
-    dest = test_dir / "dest"
+def test_reflink_unsupported_on_windows(tmp_dir_pytest_cache):
+    src = tmp_dir_pytest_cache/ "source"
+    dest = tmp_dir_pytest_cache / "dest"
     src.write_bytes(b"content")
 
     with pytest.raises(OSError) as exc:

--- a/tests/test_reflink.py
+++ b/tests/test_reflink.py
@@ -2,31 +2,16 @@ import errno
 import os
 import stat
 from os import fspath, umask
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import pytest
 
 from dvc_objects.fs.system import reflink
 
 
-@pytest.fixture
-def test_dir(request):
-    """Create a test directory within cache directory.
-
-    The cache directory by default, is in the root of the repo, where reflink
-    may be supported.
-    """
-    cache = request.config.cache
-    path = cache.mkdir("reflink_test")
-    with TemporaryDirectory(dir=path) as tmp_dir:
-        yield Path(tmp_dir)
-
-
 @pytest.mark.xfail(raises=OSError, strict=False)
-def test_reflink(test_dir):
-    src = test_dir / "source"
-    dest = test_dir / "dest"
+def test_reflink(tmp_dir_pytest_cache):
+    src = tmp_dir_pytest_cache / "source"
+    dest = tmp_dir_pytest_cache / "dest"
 
     src.write_bytes(b"content")
     reflink(fspath(src), fspath(dest))


### PR DESCRIPTION
This makes it possible to test Linux where tmpdir is using tmpfs rather than the filesystem that supports reflink.

Also we run test for 1000 links, but run 10 rounds (with 3 warmup rounds) for better results, as a single test may be noisy.