### PR TITLE
copyfile: remove callback

### DIFF
--- a/src/dvc_objects/fs/local.py
+++ b/src/dvc_objects/fs/local.py
@@ -92,7 +92,7 @@ class FsspecLocalFileSystem(fsspec.AbstractFileSystem):
         parent = self._parent(rpath)
         makedirs(parent, exist_ok=True)
         tmp_file = os.path.join(parent, tmp_fname())
-        copyfile(lpath, tmp_file, callback=callback)
+        copyfile(lpath, tmp_file)
         os.replace(tmp_file, rpath)
 
     def get_file(self, rpath, lpath, callback=None, **kwargs):
@@ -101,7 +101,7 @@ class FsspecLocalFileSystem(fsspec.AbstractFileSystem):
             self.makedirs(lpath, exist_ok=True)
             return
 
-        copyfile(rpath, lpath, callback=callback)
+        copyfile(rpath, lpath)
 
     def mv(self, path1, path2, **kwargs):
         self.makedirs(self._parent(path2), exist_ok=True)

--- a/src/dvc_objects/fs/utils.py
+++ b/src/dvc_objects/fs/utils.py
@@ -145,48 +145,12 @@ def makedirs(path, exist_ok: bool = False, mode: Optional[int] = None) -> None:
         )
 
 
-def _copyfile_with_pbar(
-    src: "AnyFSPath",
-    dest: "AnyFSPath",
-    total: int,
-    callback: Optional["Callback"] = None,
-    no_progress_bar: bool = False,
-    name: Optional[str] = None,
-):
-    from .callbacks import Callback
-
-    name = name if name else os.path.basename(dest)
-
-    if callback:
-        callback.set_size(total)
-
-    with open(src, "rb") as fsrc, open(dest, "wb+") as fdest:
-        with Callback.as_tqdm_callback(
-            callback,
-            size=total,
-            bytes=True,
-            disable=no_progress_bar,
-            desc=name,
-        ) as cb:
-            wrapped = cb.wrap_attr(fdest, "write")
-            while True:
-                buf = fsrc.read(LOCAL_CHUNK_SIZE)
-                if not buf:
-                    break
-                wrapped.write(buf)
-
-    if callback:
-        callback.absolute_update(total)
-
-
 def copyfile(
     src: "AnyFSPath",
     dest: "AnyFSPath",
     **kwargs,
 ) -> None:
     """Copy file with progress bar"""
-    total = os.stat(src).st_size
-
     if os.path.isdir(dest):
         dest = os.path.join(dest, os.path.basename(src))
 
@@ -197,12 +161,7 @@ def copyfile(
         return
     except OSError:
         pass
-
-    if total < COPY_PBAR_MIN_SIZE:
-        shutil.copyfile(src, dest)
-        return
-
-    _copyfile_with_pbar(src, dest, total, **kwargs)
+    shutil.copyfile(src, dest)
 
 
 def tmp_fname(fname: "AnyFSPath" = "") -> "AnyFSPath":


### PR DESCRIPTION
Let's remove the callback in all conditions.

The callbacks are part of fsspec, and they don't support callbacks in localfs either.
I plan on to remove `tqdm` and `TqdmCallback` from `dvc-objects`, which this was blocking.

Let's fix this properly if someone complains. :-)