### PR TITLE
objectdb: add __rich_repr__

### DIFF
--- a/src/dvc_objects/db.py
+++ b/src/dvc_objects/db.py
@@ -61,6 +61,11 @@ class ObjectDB:
         read_only = self.read_only
         return f"{self.__class__.__name__}({fs=!r}, {path=!r}, {read_only=!r})"
 
+    def __rich_repr__(self):
+        yield "fs", self.fs
+        yield "path", self.path
+        yield "read_only", self.read_only
+
     def _init(self, dname: str) -> None:
         if self.read_only:
             return


### PR DESCRIPTION
This will format `repr` nicely if you use `rich` for printing (as I do in `pdb` and `ipython`).

This may be not useful for `repr(db)`, but if you, for example have a very verbose output, this becomes very useful.

Eg:
```python
StorageMapping(
    {
        (): StorageInfo(
            data=None,
            cache=ObjectStorage(
                key=(),
                odb=HashFileDB(
                    fs=<dvc_objects.fs.local.LocalFileSystem object at 0x1109e68d0>,
                    path='/private/var/folders/xh/trg29z296h70n109kwfk6g800000gn/T/pytest-of-saugat/pytest-278/pytest-servers13',
                    read_only=False
                ),
                index=None,
                read_only=False
            ),
            remote=None
        )
    }
)
```

```python
StorageMapping({(): StorageInfo(data=None, cache=ObjectStorage(key=(), odb=HashFileDB(fs=<dvc_objects.fs.local.LocalFileSystem object at 0x1109e68d0>, path='/private/var/folders/xh/trg29z296h70n109kwfk6g800000gn/T/pytest-of-saugat/pytest-278/pytest-servers13', read_only=False), index=None, read_only=False), remote=None)})
```