### PR TITLE
use functools.cached_property on Python>=3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 requires-python = ">=3.8"
 dynamic = ["version"]
 dependencies = [
-    "funcy>=1.14",
+    "funcy>=1.14; python_version < '3.12'",
     "fsspec>=2022.10.0",
 ]
 
@@ -169,8 +169,8 @@ parametrize-names-type = "csv"
 
 [tool.ruff.lint.flake8-tidy-imports]
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
-"funcy.cached_property" = {msg = "use `from dvc_objects.utils import cached_property` instead."}
-"functools.cached_property" = {msg = "use `from dvc_objects.utils import cached_property` instead."}
+"funcy.cached_property" = {msg = "use `from dvc_objects.compat import cached_property` instead."}
+"functools.cached_property" = {msg = "use `from dvc_objects.compat import cached_property` instead."}
 
 [tool.ruff.lint.flake8-type-checking]
 strict = true

--- a/src/dvc_objects/compat.py
+++ b/src/dvc_objects/compat.py
@@ -1,6 +1,7 @@
+import sys
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
+if sys.version_info >= (3, 12) or TYPE_CHECKING:
     from functools import cached_property  # noqa: TID251
 else:
     from funcy import cached_property  # noqa: TID251

--- a/src/dvc_objects/fs/base.py
+++ b/src/dvc_objects/fs/base.py
@@ -29,8 +29,8 @@ from urllib.parse import urlsplit, urlunsplit
 import fsspec
 from fsspec.asyn import get_loop
 
+from dvc_objects.compat import cached_property
 from dvc_objects.executors import ThreadPoolExecutor, batch_coros
-from dvc_objects.utils import cached_property
 
 from .callbacks import (
     DEFAULT_CALLBACK,

--- a/src/dvc_objects/fs/local.py
+++ b/src/dvc_objects/fs/local.py
@@ -1,12 +1,8 @@
 import logging
 import os
 import shutil
-import threading
 
 import fsspec
-from funcy import wrap_prop
-
-from dvc_objects.utils import cached_property
 
 from . import system
 from .base import FileSystem
@@ -185,10 +181,9 @@ class LocalFileSystem(FileSystem):
     PARAM_PATH = "path"
     TRAVERSE_PREFIX_LEN = 2
 
-    @wrap_prop(threading.Lock())  # type: ignore[misc]
-    @cached_property
-    def fs(self):
-        return FsspecLocalFileSystem(**self.config)
+    def __init__(self, fs=None, **kwargs):
+        fs = fs or FsspecLocalFileSystem(**kwargs)
+        super().__init__(fs, **kwargs)
 
     def getcwd(self):
         return os.getcwd()


### PR DESCRIPTION
cached_property on Python>=3.12 does not have a lock, so we can use it instead of funcy. This means that now we don't need to depend on funcy at all for Python>=3.12, and is optional.