### PR TITLE
TqdmCallback: fix typo/off-by-one error

### DIFF
--- a/src/dvc_objects/fs/callbacks.py
+++ b/src/dvc_objects/fs/callbacks.py
@@ -41,11 +41,10 @@ class TqdmCallback(fsspec.callbacks.TqdmCallback):
         from dvc_objects._tqdm import Tqdm
 
         tqdm_kwargs.pop("total", None)
-        tqdm_cls = tqdm_cls or Tqdm
         super().__init__(
-            tqdm_kwargs=tqdm_kwargs, tqdm_cls=tqdm_cls, size=size, value=value
+            tqdm_kwargs=tqdm_kwargs, tqdm_cls=tqdm_cls or Tqdm, size=size, value=value
         )
-        if progress_bar is None:
+        if progress_bar is not None:
             self.tqdm = progress_bar
 
     def branched(self, path_1: "Union[str, BinaryIO]", path_2: str, **kwargs):


### PR DESCRIPTION
`self.tqdm` should be set if progress_bar is passed.